### PR TITLE
Make the API class a base class containing network-related methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,8 @@
 # CoffeeHouse API Wrapper for Python
 
 This is a very simple API Wrapper for the CoffeeHouse API. Using
-This Library only supports the V1IVA2.0 API which is based from
+This Library only supports the V1IVA2.0 Lydia API which is based from
 this [Documentation](https://gist.github.com/Netkas/e8977b26f482ca40911a949df7dd286f)
-
-<p align="center">
-  <img src="https://i.imgur.com/DjuRyhZ.jpg" alt="CoffeeHouse Python Example">
-</p>
 
 
 ## Installation
@@ -25,13 +21,12 @@ python setup.py install
 
 ```python
 from coffeehouse.lydia import LydiaAI
-from coffeehouse.api import API
 
 # Create the CoffeeHouse API instance
-coffeehouse_api = API("<API KEY>")
+api_key = input("API Key: ")
 
 # Create Lydia instance
-lydia = LydiaAI(coffeehouse_api)
+lydia = LydiaAI(api_key)
 
 # Create a new chat session (Like a conversation)
 session = lydia.create_session()
@@ -44,4 +39,13 @@ print("Session Expires: {0}".format(str(session.expires)))
 while True:
     output = session.think_thought(input("Input: "))
     print("Output: {0}".format(output))
+
+# In the case you want to save the Session ID to reuse the session
+# Use lydia to invoke think_thought instead, for example;
+#
+# while(True):
+#     output = lydia.think_thought(session.id, input("Input: "))
+#     print("Output: {0}".format(output))
+#
+# This is the same effect as above but uses the lydia instance directly.
 ```

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # CoffeeHouse API Wrapper for Python
 
 This is a very simple API Wrapper for the CoffeeHouse API. Using
-This Library only supports the V1IVA2.0 Lydia API which is based from
+This Library only supports the V1IVA2.0 CoffeeHouse API which is based from
 this [Documentation](https://gist.github.com/Netkas/e8977b26f482ca40911a949df7dd286f)
 
 

--- a/coffeehouse/__init__.py
+++ b/coffeehouse/__init__.py
@@ -1,7 +1,15 @@
-from coffeehouse.api import *
-from coffeehouse.exception import *
+from . import api
+from .api import *  # noqa: F403,F401
 
-__all__ = ['api', 'exception']
+from . import exception
+from .exception import *  # noqa: F403,F401
+
+from . import lydia
+from .lydia import *  # noqa: F403,F401
+
+__all__ = ["api",
+           "exception",
+           "lydia"] + api.__all__ + exception.__all__ + lydia.__all__
 __version__ = "2.1.0"
 __author__ = "Intellivoid Technologies"
 __source__ = "https://github.com/intellivoid/CoffeeHouse-Python-API-Wrapper"

--- a/coffeehouse/api.py
+++ b/coffeehouse/api.py
@@ -14,3 +14,7 @@ class API(object):
         else:
             self.access_key = access_key
             self.endpoint = endpoint
+
+    def _send(self, path, payload):
+        response = requests.post("{}/{}".format(self.endpoint, path), payload)
+        return CoffeeHouseError.parse_and_raise(response.status_code, response.text)

--- a/coffeehouse/api.py
+++ b/coffeehouse/api.py
@@ -1,11 +1,29 @@
-class API(object):
+from .exception import CoffeeHouseError
 
-    def __init__(self, access_key, endpoint="https://api.intellivoid.info/coffeehouse"):
+import requests
+
+
+__all__ = ["API"]
+
+
+class API(object):
+    """
+    Base class for all CoffeeHouse services
+    It can be instantiated by itself as a holder for the API key,
+    or it can be subclassed by CoffeeHouse services
+
+    :param access_key: Access key from coffeehouse.intellivoid.info
+    :param endpoint: Base URL for all requests, without the trailing slash
+    """
+
+    def __init__(self, access_key,
+                 endpoint="https://api.intellivoid.info/coffeehouse"):
         """
         Public base constructor for CoffeeHouse API
-        It can be 
+        It can be instantiated by itself as a holder for the API key,
+        or it can be subclassed by CoffeeHouse services
 
-        :param access_key: Access key available from coffeehouse.intellivoid.info
+        :param access_key: Access key from coffeehouse.intellivoid.info
         :param endpoint: Base URL for all requests, without the trailing slash
         """
         if isinstance(access_key, API):
@@ -18,7 +36,7 @@ class API(object):
     def _send(self, path, access_key=True, **payload):
         """
         Send a request to the server configured by self.endpoint.
-        
+
         :param path: The path over the base URL, without the preceding slash
         :type path: str
         :return: The response, parsed
@@ -27,4 +45,5 @@ class API(object):
         if access_key:
             payload["access_key"] = self.access_key
         response = requests.post("{}/{}".format(self.endpoint, path), payload)
-        return CoffeeHouseError.parse_and_raise(response.status_code, response.text)
+        return CoffeeHouseError.parse_and_raise(response.status_code,
+                                                response.text)["payload"]

--- a/coffeehouse/api.py
+++ b/coffeehouse/api.py
@@ -8,5 +8,9 @@ class API(object):
         :param endpoint:
         :return:
         """
-        self.access_key = access_key
-        self.endpoint = endpoint
+        if isinstance(access_key, API):
+            self.access_key = access_key.access_key
+            self.endpoint = access_key.endpoint
+        else:
+            self.access_key = access_key
+            self.endpoint = endpoint

--- a/coffeehouse/api.py
+++ b/coffeehouse/api.py
@@ -2,11 +2,11 @@ class API(object):
 
     def __init__(self, access_key, endpoint="https://api.intellivoid.info/coffeehouse"):
         """
-        Public constructor for CoffeeHouse API
+        Public base constructor for CoffeeHouse API
+        It can be 
 
-        :param access_key:
-        :param endpoint:
-        :return:
+        :param access_key: Access key available from coffeehouse.intellivoid.info
+        :param endpoint: Base URL for all requests, without the trailing slash
         """
         if isinstance(access_key, API):
             self.access_key = access_key.access_key
@@ -15,6 +15,16 @@ class API(object):
             self.access_key = access_key
             self.endpoint = endpoint
 
-    def _send(self, path, payload):
+    def _send(self, path, access_key=True, **payload):
+        """
+        Send a request to the server configured by self.endpoint.
+        
+        :param path: The path over the base URL, without the preceding slash
+        :type path: str
+        :return: The response, parsed
+        :rtype: dict
+        """
+        if access_key:
+            payload["access_key"] = self.access_key
         response = requests.post("{}/{}".format(self.endpoint, path), payload)
         return CoffeeHouseError.parse_and_raise(response.status_code, response.text)

--- a/coffeehouse/exception.py
+++ b/coffeehouse/exception.py
@@ -11,6 +11,7 @@ class CoffeeHouseError(Exception):
     :param message: Response content returned by the server
     :type message: str
     """
+    
     def __init__(self, status_code, content):
         self.status_code = status_code
         self.content = content
@@ -29,6 +30,7 @@ class CoffeeHouseError(Exception):
         :type content: str
         :rtype dict
         """
+        
         try:
             response = json.loads(content)
         except json.decoder.JSONDecodeError:

--- a/coffeehouse/exception.py
+++ b/coffeehouse/exception.py
@@ -1,6 +1,9 @@
 import json
 
 
+__all__ = ["CoffeeHouseError"]
+
+
 class CoffeeHouseError(Exception):
     """
     Exception raised by API errors.
@@ -11,7 +14,7 @@ class CoffeeHouseError(Exception):
     :param message: Response content returned by the server
     :type message: str
     """
-    
+
     def __init__(self, status_code, content):
         self.status_code = status_code
         self.content = content
@@ -23,14 +26,14 @@ class CoffeeHouseError(Exception):
         """
         Raise an exception if applicable, otherwise return the
         response of the method
-        
+
         :param status_code: Status code returned by the server
         :type status_code: int
         :param content: Response content returned by the server
         :type content: str
         :rtype dict
         """
-        
+
         try:
             response = json.loads(content)
         except json.decoder.JSONDecodeError:
@@ -39,7 +42,6 @@ class CoffeeHouseError(Exception):
             raise _mapping.get(status_code,
                                CoffeeHouseError)(status_code, response)
         return response
-        
 
 
 class ApiSuspendedError(CoffeeHouseError):
@@ -63,9 +65,9 @@ class SessionNotFoundError(CoffeeHouseError):
 
 
 _mapping = {
-            400: SessionInvalidError,
-            401: InvalidApiKeyError,
-            403: ApiSuspendedError,
-            404: SessionNotFoundError,
-            503: AIError
-           }
+    400: SessionInvalidError,
+    401: InvalidApiKeyError,
+    403: ApiSuspendedError,
+    404: SessionNotFoundError,
+    503: AIError
+}

--- a/coffeehouse/exception.py
+++ b/coffeehouse/exception.py
@@ -9,22 +9,35 @@ class CoffeeHouseError(Exception):
     :param status_code: Status code returned by the server
     :type status_code: int
     :param message: Response content returned by the server
-    :type message: string
+    :type message: str
     """
     def __init__(self, status_code, content):
         self.status_code = status_code
         self.content = content
-        try:
-            self.message = json.loads(content).get("message", None)
-        except json.decoder.JSONDecodeError:
-            self.message = "Unknown"
+        self.message = content.get("message", None) if content else "Unknown"
         super().__init__(self.message or content)
 
     @staticmethod
-    def raise_for_status(status_code, message):
+    def parse_and_raise(status_code, content):
+        """
+        Raise an exception if applicable, otherwise return the
+        response of the method
+        
+        :param status_code: Status code returned by the server
+        :type status_code: int
+        :param content: Response content returned by the server
+        :type content: str
+        :rtype dict
+        """
+        try:
+            response = json.loads(content)
+        except json.decoder.JSONDecodeError:
+            raise CoffeeHouseError(status_code, None)
         if status_code != 200:
             raise _mapping.get(status_code,
-                               CoffeeHouseError)(status_code, message)
+                               CoffeeHouseError)(status_code, response)
+        return response
+        
 
 
 class ApiSuspendedError(CoffeeHouseError):

--- a/coffeehouse/lydia/__init__.py
+++ b/coffeehouse/lydia/__init__.py
@@ -1,4 +1,8 @@
-from coffeehouse.lydia.lydia_ai import *
-from coffeehouse.lydia.session import *
+from . import lydia_ai
+from .lydia_ai import *  # noqa: F403,F401
 
-__all__ = ['lydia_ai', 'session']
+from . import session
+from .session import *  # noqa: F403,F401
+
+
+__all__ = ["lydia_ai", "session"] + lydia_ai.__all__ + session.__all__

--- a/coffeehouse/lydia/lydia_ai.py
+++ b/coffeehouse/lydia/lydia_ai.py
@@ -23,18 +23,12 @@ class LydiaAI(API):
         :type language: str
         :param language: The language that this session will be based in
         :raises: CoffeeHouseError
-        :returns: A ``Session`` object
+        :returns: The newly created session
         :rtype: Session
         """
 
-        request_payload = {
-            "access_key": self.access_key,
-            "target_language": language
-        }
-
-        response = requests.post("{0}/v1/lydia/session/create".format(self.endpoint), request_payload)
-        CoffeeHouseError.raise_for_status(response.status_code, response.text)
-        return Session(json.loads(response.text)["payload"], self)
+        return Session(self._send("v1/lydia/session/create",
+                                  target_language=language), self)
 
     def get_session(self, session_id):
         """
@@ -43,18 +37,12 @@ class LydiaAI(API):
         :type session_id: int
         :param session_id: The ID of the session to retrieve
         :raises: CoffeeHouseError
-        :returns: A ``Session`` object
+        :returns: The already existing session
         :rtype: Session
         """
 
-        request_payload = {
-            "access_key": self.access_key,
-            "session_id": session_id
-        }
-
-        response = requests.post("{0}/v1/lydia/session/get".format(self.endpoint), request_payload)
-        CoffeeHouseError.raise_for_status(response.status_code, response.text)
-        return Session(json.loads(response.text)["payload"], self)
+        return Session(self._send("v1/lydia/session/get",
+                                  session_id=session_id), self)
 
     def think_thought(self, session_id, text):
         """
@@ -67,14 +55,7 @@ class LydiaAI(API):
         :returns: The json payload of the response
         :rtype: str
         """
-
-        request_payload = {
-            "access_key": self.access_key,
-            "session_id": session_id,
-            "input": text
-        }
-
-        response = requests.post("{0}/v1/lydia/session/think".format(self.endpoint),
-                                 request_payload)
-        CoffeeHouseError.raise_for_status(response.status_code, response.text)
-        return json.loads(response.text)["payload"]["output"]
+        
+        return self._send("v1/lydia/session/think",
+                          session_id=session_id,
+                          input=text)["payload"]["output"]

--- a/coffeehouse/lydia/lydia_ai.py
+++ b/coffeehouse/lydia/lydia_ai.py
@@ -1,9 +1,8 @@
-from coffeehouse.exception import CoffeeHouseError
-from coffeehouse.lydia.session import Session
-from coffeehouse.api import API
+from .session import LydiaSession
+from ..api import API
 
-import json
-import requests
+
+__all__ = ["LydiaAI"]
 
 
 class LydiaAI(API):
@@ -18,31 +17,31 @@ class LydiaAI(API):
 
     def create_session(self, language="en"):
         """
-        Creates a new Session with the AI
+        Creates a new LydiaSession with the AI
 
         :type language: str
         :param language: The language that this session will be based in
         :raises: CoffeeHouseError
         :returns: The newly created session
-        :rtype: Session
+        :rtype: LydiaSession
         """
 
-        return Session(self._send("v1/lydia/session/create",
-                                  target_language=language), self)
+        return LydiaSession(self._send("v1/lydia/session/create",
+                                       target_language=language), self)
 
     def get_session(self, session_id):
         """
-        Gets an existing session using a Session ID
+        Gets an existing session using a LydiaSession ID
 
         :type session_id: int
         :param session_id: The ID of the session to retrieve
         :raises: CoffeeHouseError
         :returns: The already existing session
-        :rtype: Session
+        :rtype: LydiaSession
         """
 
-        return Session(self._send("v1/lydia/session/get",
-                                  session_id=session_id), self)
+        return LydiaSession(self._send("v1/lydia/session/get",
+                                       session_id=session_id), self)
 
     def think_thought(self, session_id, text):
         """
@@ -55,7 +54,7 @@ class LydiaAI(API):
         :returns: The json payload of the response
         :rtype: str
         """
-        
+
         return self._send("v1/lydia/session/think",
                           session_id=session_id,
-                          input=text)["payload"]["output"]
+                          input=text)["output"]

--- a/coffeehouse/lydia/lydia_ai.py
+++ b/coffeehouse/lydia/lydia_ai.py
@@ -6,16 +6,15 @@ import json
 import requests
 
 
-class LydiaAI:
-
-    def __init__(self, coffeehouse_api):
+class LydiaAI(API):
+    def __init__(self, *args, **kwargs):
         """
         Public constructor for Lydia
-
-        :type coffeehouse_api: API
+        :param access_key:
+        :param endpoint:
         """
 
-        self.api = coffeehouse_api
+        super().__init__(*args, **kwargs)
 
     def create_session(self, language="en"):
         """
@@ -29,11 +28,11 @@ class LydiaAI:
         """
 
         request_payload = {
-            "access_key": self.api.access_key,
+            "access_key": self.access_key,
             "target_language": language
         }
 
-        response = requests.post("{0}/v1/lydia/session/create".format(self.api.endpoint), request_payload)
+        response = requests.post("{0}/v1/lydia/session/create".format(self.endpoint), request_payload)
         CoffeeHouseError.raise_for_status(response.status_code, response.text)
         return Session(json.loads(response.text)["payload"], self)
 
@@ -49,11 +48,11 @@ class LydiaAI:
         """
 
         request_payload = {
-            "access_key": self.api.access_key,
+            "access_key": self.access_key,
             "session_id": session_id
         }
 
-        response = requests.post("{0}/v1/lydia/session/get".format(self.api.endpoint), request_payload)
+        response = requests.post("{0}/v1/lydia/session/get".format(self.endpoint), request_payload)
         CoffeeHouseError.raise_for_status(response.status_code, response.text)
         return Session(json.loads(response.text)["payload"], self)
 
@@ -70,12 +69,12 @@ class LydiaAI:
         """
 
         request_payload = {
-            "access_key": self.api.access_key,
+            "access_key": self.access_key,
             "session_id": session_id,
             "input": text
         }
 
-        response = requests.post("{0}/v1/lydia/session/think".format(self.api.endpoint),
+        response = requests.post("{0}/v1/lydia/session/think".format(self.endpoint),
                                  request_payload)
         CoffeeHouseError.raise_for_status(response.status_code, response.text)
         return json.loads(response.text)["payload"]["output"]

--- a/coffeehouse/lydia/session.py
+++ b/coffeehouse/lydia/session.py
@@ -1,14 +1,17 @@
-class Session(object):
+__all__ = ["LydiaSession", "Session"]
+
+
+class LydiaSession:
     def __init__(self, data, client):
         """
         AI Session Object
         """
 
         self._client = client
-        self.id = data['session_id']
-        self.language = data['language']
-        self.available = data['available']
-        self.expires = data['expires']
+        self.id = data["session_id"]
+        self.language = data["language"]
+        self.available = data["available"]
+        self.expires = data["expires"]
 
     def think_thought(self, text):
         """
@@ -32,3 +35,6 @@ class Session(object):
         """
 
         return self.id
+
+
+Session = LydiaSession  # For compatibility

--- a/coffeehouse/lydia/session.py
+++ b/coffeehouse/lydia/session.py
@@ -1,5 +1,4 @@
 class Session(object):
-
     def __init__(self, data, client):
         """
         AI Session Object
@@ -26,7 +25,7 @@ class Session(object):
 
     def __str__(self):
         """
-        Returns ``str(self)``
+        Returns an identifier uniquely specifying this session
 
         :returns: The session id
         :rtype: str

--- a/examples/lydia_example.py
+++ b/examples/lydia_example.py
@@ -1,12 +1,10 @@
 from coffeehouse.lydia import LydiaAI
-from coffeehouse.api import API
 
 # Create the CoffeeHouse API instance
-api_key = "<API KEY>"
-coffeehouse_api = API(api_key)
+api_key = input("API Key: ")
 
 # Create Lydia instance
-lydia = LydiaAI(coffeehouse_api)
+lydia = LydiaAI(api_key)
 
 # Create a new chat session (Like a conversation)
 session = lydia.create_session()

--- a/examples/lydia_example.py
+++ b/examples/lydia_example.py
@@ -1,4 +1,4 @@
-from coffeehouse.lydia import LydiaAI
+from coffeehouse import LydiaAI
 
 # Create the CoffeeHouse API instance
 api_key = input("API Key: ")

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as file:
 
 setup(
     name='coffeehouse',
-    version='2.1.0',
+    version='3.0.0',
     description='Official CoffeeHouse API Wrapper for Python',
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
Actually, the new ABI is compatible with the 1.x.y series. This sets us back to the 1.x.y ABI so that existing code is compatible. It adds a common base class for CoffeeHouse. 